### PR TITLE
feat(Issue #65.1): scaffold dashboard UI components (ThemeToggle, Car…

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5002   # polls-service default port

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: "primary" | "secondary" | "destructive";
+};
+
+export default function Button({ variant = "primary", className = "", children, ...rest }: Props) {
+  const base = "px-md py-sm rounded-md font-medium";
+  const variants: Record<string, string> = {
+    primary: "bg-primary text-surface hover:opacity-90",
+    secondary: "bg-secondary text-textPrimary hover:opacity-90",
+    destructive: "bg-error text-surface hover:opacity-90",
+  };
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Card({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`bg-surface rounded-lg shadow-md p-md ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState<boolean>(() => {
+    try {
+      const val = localStorage.getItem("votewave_theme");
+      if (val) return val === "dark";
+      // init from system
+      return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add("dark");
+      localStorage.setItem("votewave_theme", "dark");
+    } else {
+      root.classList.remove("dark");
+      localStorage.setItem("votewave_theme", "light");
+    }
+  }, [dark]);
+
+  return (
+    <button
+      aria-label="toggle theme"
+      onClick={() => setDark((d) => !d)}
+      className="p-2 rounded-md hover:bg-surface/60"
+      title="Toggle theme"
+    >
+      {dark ? <Sun className="w-5 h-5 text-primary" /> : <Moon className="w-5 h-5 text-textSecondary" />}
+    </button>
+  );
+}

--- a/frontend/src/layouts/DashboardLayout.tsx
+++ b/frontend/src/layouts/DashboardLayout.tsx
@@ -4,6 +4,7 @@
 import React from "react";
 import { Link, Outlet } from "react-router-dom";
 import { Bell, Home, BarChart2, Repeat, User, Settings } from "lucide-react";
+import ThemeToggle from "../components/ThemeToggle";
 
 export default function DashboardLayout() {
   return (
@@ -26,11 +27,12 @@ export default function DashboardLayout() {
 
         {/* Right: Actions */}
         <div className="flex items-center space-x-md">
-          <button className="relative">
+          <ThemeToggle />
+          <button className="relative" aria-label="notifications">
             <Bell className="w-6 h-6 text-textSecondary" />
             <span className="absolute -top-1 -right-1 w-2 h-2 bg-error rounded-full"></span>
           </button>
-          <Link to="/profile">
+          <Link to="/profile" aria-label="profile">
             <User className="w-7 h-7 text-textSecondary" />
           </Link>
         </div>
@@ -43,16 +45,16 @@ export default function DashboardLayout() {
 
       {/* Mobile Bottom Nav */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-surface shadow-md flex justify-around py-sm border-t">
-        <Link to="/home">
+        <Link to="/home" aria-label="home">
           <Home className="w-6 h-6 text-textSecondary" />
         </Link>
-        <Link to="/mypolls">
+        <Link to="/mypolls" aria-label="mypolls">
           <BarChart2 className="w-6 h-6 text-textSecondary" />
         </Link>
-        <Link to="/repost">
+        <Link to="/repost" aria-label="repost">
           <Repeat className="w-6 h-6 text-textSecondary" />
         </Link>
-        <Link to="/settings">
+        <Link to="/settings" aria-label="settings">
           <Settings className="w-6 h-6 text-textSecondary" />
         </Link>
       </nav>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import DashboardLayout from "./layouts/DashboardLayout.tsx";
 import DashboardHome from "./pages/DashboardHome";
+import PollList from "./pages/PollList";
+import PollDetail from "./pages/PollDetail";
 
 const router = createBrowserRouter([
   {
@@ -15,7 +17,13 @@ const router = createBrowserRouter([
       { path: "repost", element: <div className="p-6">🔁 Repost Page</div> },
       { path: "analytics", element: <div className="p-6">📈 Analytics Page</div> },
       { path: "settings", element: <div className="p-6">⚙️ Settings Page</div> },
+      { path: "polls", element: <PollList /> },
+      { path: "polls/:id", element: <PollDetail /> },
     ],
   },
 ]);
-
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/PollDetail.tsx
+++ b/frontend/src/pages/PollDetail.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import Card from "../components/Card";
+import Button from "../components/Button";
+
+/**
+ * PollDetail: stub page — shows poll id and dummy options.
+ * Later: replace dummy with fetch(VITE_API_URL + `/polls/${id}`)
+ */
+
+export default function PollDetail() {
+  const { id } = useParams();
+  const options = ["Yes", "No", "Maybe"];
+
+  return (
+    <div>
+      <h2 className="text-h2 text-textPrimary mb-md">Poll #{id}</h2>
+      <Card>
+        <h3 className="text-h3 text-textPrimary mb-sm">(Dummy) Should we adopt this policy?</h3>
+        <div className="space-y-sm">
+          {options.map((o) => (
+            <div key={o} className="flex items-center justify-between">
+              <span className="text-body">{o}</span>
+              <Button
+                onClick={() => {
+                  // smoke action - will be replaced by API call later
+                  console.log("VOTE", { pollId: id, option: o });
+                  alert(`Vote recorded (local stub): ${o}`);
+                }}
+              >
+                Vote
+              </Button>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/PollList.tsx
+++ b/frontend/src/pages/PollList.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Card from "../components/Card";
+import Button from "../components/Button";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * PollList: simple scaffold with dummy data so we can test UI.
+ * Later we will wire fetch() to VITE_API_URL + /api/polls
+ */
+
+const DUMMY = [
+  { id: 1, question: "Should remote work be the new normal?", votes: 452 },
+  { id: 2, question: "Do you support climate action policies?", votes: 327 },
+  { id: 3, question: "Should the school year start later?", votes: 214 },
+];
+
+export default function PollList() {
+  const nav = useNavigate();
+
+  return (
+    <div className="space-y-md">
+      <h2 className="text-h2 text-textPrimary">Available Polls</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-md">
+        {DUMMY.map((p) => (
+          <Card key={p.id}>
+            <h3 className="text-h3 text-textPrimary mb-sm">{p.question}</h3>
+            <p className="text-body text-textSecondary mb-sm">📊 {p.votes} votes</p>
+            <div className="flex justify-end">
+              <Button
+                onClick={() => {
+                  console.log("NAV to poll detail", p.id);
+                  nav(`/polls/${p.id}`);
+                }}
+              >
+                View / Vote
+              </Button>
+            </div>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Small UI scaffolding for Dashboard:
- ThemeToggle component + integrated into header
- Reusable Card & Button components
- PollList page (dummy data) and PollDetail page (stub)
- Added frontend/.env.example and wired routes in main.tsx

## Files changed
- frontend/src/layouts/DashboardLayout.tsx
- frontend/src/components/ThemeToggle.tsx
- frontend/src/components/Card.tsx
- frontend/src/components/Button.tsx
- frontend/src/pages/PollList.tsx
- frontend/src/pages/PollDetail.tsx
- frontend/src/main.tsx
- frontend/.env.example

## How to test locally
1. cd frontend
2. npm install
3. npm run dev
4. Visit http://localhost:5173
5. Verify header + theme toggle works
6. Go to /polls and click a poll; verify PollDetail stub and Vote alert

## Notes
- Dev recommendation: use Node 18+.
- Tailwind: repo currently references tailwind; if build errors occur, run `npm install tailwindcss@^3.4.24 postcss autoprefixer --save-dev` as suggested in the issue body.
